### PR TITLE
Fixes for lein 1.3 and Clojure 1.2 in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,9 +21,9 @@ Ring Jetty adapter as dependencies:
 {% highlight clj %}
 (defproject hello-www "1.0.0-SNAPSHOT"
   :description "A Compojure 'Hello World' application"
-  :dependencies [[org.clojure/clojure "1.1.0"]
-                 [org.clojure/clojure-contrib "1.1.0"]
-                 [compojure "0.4.0"]
+  :dependencies [[org.clojure/clojure "1.2.0"]
+                 [org.clojure/clojure-contrib "1.2.0"]
+                 [compojure "0.4.1"]
                  [ring/ring-jetty-adapter "0.2.3"]]
   :main hello-www.core)
 {% endhighlight %}


### PR DESCRIPTION
The lein repl incantation has been tripping up a lot of new users, as lein 1.3 no longer accepts the script argument.

The example project dependencies could name newer stable versions of Clojure and Compojure too.
