### PR TITLE
fixes failing test ("with string") in response.clj

### DIFF
--- a/test/compojure/test/response.clj
+++ b/test/compojure/test/response.clj
@@ -7,7 +7,7 @@
 
 (def expected-response
   {:status  200
-   :headers {"Content-Type" "text/html"}
+   :headers {"Content-Type" "text/html; charset=utf-8"}
    :body    "<h1>Foo</h1>"})
 
 (deftest response-test


### PR DESCRIPTION
introduced in edf7406cb053c96aaad3fb320742941acb709914 by adding a
default charset header to response
