### PR TITLE
add content-type header for (render seq)

### DIFF
--- a/src/compojure/response.clj
+++ b/src/compojure/response.clj
@@ -30,7 +30,8 @@
   File
   (render [file _] (response file))
   ISeq
-  (render [coll _] (response coll))
+  (render [coll _] (-> (response coll)
+                       (content-type "text/html; charset=utf-8")))
   InputStream
   (render [stream _] (response stream))
   URL

--- a/test/compojure/test/response.clj
+++ b/test/compojure/test/response.clj
@@ -18,6 +18,12 @@
     (is (= (response/render "<h1>Foo</h1>" {})
            expected-response)))
 
+  (testing "with string seq"
+    (let [response (response/render '("<h1>" "Foo" "</h1>") {})]
+      (is (seq? (:body response)))
+      (is (= (:headers response)
+             {"Content-Type" "text/html; charset=utf-8"}))))
+
   (testing "with handler function"
     (is (= (response/render (constantly expected-response) {})
            expected-response)))


### PR DESCRIPTION
The reason for doing this:

Enlive templates return seqs of strings:
http://clj-me.cgrand.net/2010/02/10/why-enlive-templates-return-seqs-of-strings/

But if just return 

``` clj
(enlive-template)
```

 to compojure, then no content-type header is set.

Other 2 choice are

``` clj
{:status  200
 :headers {"Content-Type" "text/html; charset=utf-8"}
 :body    (enlive-template)}
```

``` clj
(apply str (enlive-template)) 
```

The 2 above are not as good as modify comojure, and I think others may also need this, 
so, I send this poll request.
