### PR TITLE
Make compile-route public to enable custom HTTP methods

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -92,7 +92,7 @@
       (fn [request]
         (render (handler request) request)))))
 
-(defn- compile-route
+(defn compile-route
   "Compile a route in the form (method path & body) into a function."
   [method route bindings body]
   `(make-route


### PR DESCRIPTION
This way, anyone can define custom HTTP methods, e.g. LOGIN, and won't have to wait until compojure adds support for a specific one.
