### PR TITLE
ANY accepts a set of methods

### DIFF
--- a/test/compojure/test/core.clj
+++ b/test/compojure/test/core.clj
@@ -57,6 +57,28 @@
           route (PUT "/foo" [] resp)]
       (is (= (route req) resp))))
 
+  (testing "ANY"
+    (testing "with methods set"
+      (let [resp {:status 200, :headers {}, :body "bar"}
+            route (ANY #{:put :post} "/foo" [] resp)]
+        (is (= (route (request :put "/foo")) resp))
+        (is (= (route (request :post "/foo")) resp))
+        (is (= (route (-> (request :post "/foo")
+                          (assoc :form-params {"_method" "PUT"})))
+               resp))
+        (is (nil? (route (request :get "/foo"))))
+        (is (nil? (route (-> (request :post "/foo")
+                             (assoc :form-params {"_method" "DELETE"})))))))
+
+    (testing "without methods"
+       (let [resp {:status 200, :headers {}, :body "bar"}
+            route (ANY "/foo" [] resp)]
+        (is (= (route (request :put "/foo")) resp))
+        (is (= (route (request :post "/foo")) resp))
+        (is (= (route (-> (request :post "/foo")
+                          (assoc :form-params {"_method" "PUT"})))
+               resp)))))
+
   (testing "HEAD requests"
     (let [resp  {:status 200, :headers {"X-Foo" "foo"}, :body "bar"}
           route (GET "/foo" []  resp)]


### PR DESCRIPTION
Sometimes it is useful to match a set of methods. Right now a compojure route can only accept only one or all HTTP verbs. This change makes it possible to accept any subset of the verbs

After this change the following syntaxes are valid

  (ANY "/foo" [] resp)  (this is the old syntax, of course, still valid)

  (ANY #{:get :put} "/foo" [] resp)

The second version will match only if the method is :get or :put
