### PR TITLE
Ensure that `render` retains the metadata on any provided response map

### DIFF
--- a/src/compojure/response.clj
+++ b/src/compojure/response.clj
@@ -20,7 +20,8 @@
         (content-type "text/html; charset=utf-8")))
   APersistentMap
   (render [resp-map _]
-    (merge (response "") resp-map))
+    (merge (with-meta (response "") (meta resp-map))
+           resp-map))
   IFn
   (render [func request]
     (render (func request) request))

--- a/test/compojure/test/response.clj
+++ b/test/compojure/test/response.clj
@@ -40,4 +40,9 @@
   (testing "with stream URL"
     (let [response (response/render (io/resource "ring/util/response.clj") {})]
       (is (instance? InputStream (:body response)))
-      (is (.contains (slurp (:body response)) "(ns ring.util.response")))))
+      (is (.contains (slurp (:body response)) "(ns ring.util.response"))))
+  
+  (testing "with map + metadata"
+    (let [response (response/render ^{:has-metadata? true} {:body "foo"} {})]
+      (is (= (:body response) "foo"))
+      (is (= (meta response) {:has-metadata? true})))))


### PR DESCRIPTION
Upstream adapters or middleware (in my particular case, Friend) may provide functionality based on metadata found on response maps.  The map implementation of `render` currently merges response maps into an "empty" map, thus losing any metadata on the former.
