### PR TITLE
When part of the URI is encoded using percent encoding, the context is incorrectly computed.

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -154,7 +154,7 @@
 
 (defn- wrap-context [handler]
   (fn [request]
-    (let [uri     (:uri request)
+    (let [uri     (path-decode (:uri request))
           path    (:path-info request uri)
           context (or (:context request) "")
           subpath (-> request :route-params :__path-info)]

--- a/test/compojure/test/core.clj
+++ b/test/compojure/test/core.clj
@@ -101,9 +101,10 @@
   (testing "context key"
     (let [handler (context "/foo/:id" [id] :context)]
       (are [url ctx] (= (handler (request :get url)) ctx)
-        "/foo/10"     "/foo/10"
-        "/foo/10/bar" "/foo/10"
-        "/bar/10"     nil)))
+        "/foo/10"       "/foo/10"
+        "/foo/10/bar"   "/foo/10"
+        "/foo/10/b%20r" "/foo/10"
+        "/bar/10"       nil)))
   (testing "path-info key"
     (let [handler (context "/foo/:id" [id] :path-info)]
       (are [url ctx] (= (handler (request :get url)) ctx)


### PR DESCRIPTION
This is due to `compojure.core/wrap-context` calling `remove-suffix` with an undecoded `uri` and a decoded `subpath`.  So the counts are off because `%20` in `uri` is ` ` in subpath, for example.

Also, `path` and `context` (in that same `let`) don't seemed to be used.  Am I missing something?
