### PR TITLE
made _method case insensitive

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -12,7 +12,8 @@
   (let [request-method (request :request-method)
         form-method    (get-in request [:form-params "_method"])]
     (if (and form-method (= request-method :post))
-      (= (str/upper-case (name method)) form-method)
+      (= (str/upper-case (name method))
+         (str/upper-case form-method))
       (= method request-method))))
 
 (defn- if-method

--- a/test/compojure/test/core.clj
+++ b/test/compojure/test/core.clj
@@ -57,6 +57,13 @@
           route (PUT "/foo" [] resp)]
       (is (= (route req) resp))))
 
+  (testing "_method parameter case-insenstive"
+    (let [req (-> (request :post "/foo")
+                  (assoc :form-params {"_method" "delete"}))
+          resp {:status 200, :headers {}, :body "bar"}
+          route (DELETE "/foo" [] resp)]
+      (is (= (route req) resp))))
+
   (testing "HEAD requests"
     (let [resp  {:status 200, :headers {"X-Foo" "foo"}, :body "bar"}
           route (GET "/foo" []  resp)]


### PR DESCRIPTION
i missed this functionality from the docs (tried _delete_ and it didn't work) so rolled my own...

https://github.com/rodnaph/wrap-verbs

unless there's a good reason to require uppercase?
