### PR TITLE
Add wrapped-routes macro

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -199,3 +199,18 @@
   (let [...] (routes ...))"
   [bindings & body]
   `(let ~bindings (routes ~@body)))
+
+(defn- wrap-route [f [v p as b]]
+  `(~v ~p ~as (~f (partial render ~b))))
+
+(defmacro wrapped-routes 
+  "Takes a middleware function and a body of routes. The middleware will only 
+  be called with the underlying route's body if the route matches a request, 
+  and after bindings. 
+  This is useful if the middleware itself has routing side-effects, e.g. 
+  lib-noir's wrap-force-ssl. 
+  Equivalent to:
+  (routes (verb path args (f (partial render route-body))) ...)"
+  [f & body]
+  (list* `routes (map (partial wrap-route f) body)))
+


### PR DESCRIPTION
Add wrapped-routes macro as a clean way of defining a set of routes that should all use the same side-effecting middleware.

Hi James,

re: this thread on the Google group - https://groups.google.com/forum/#!topic/compojure/o5l9m7nbGlE, here's a macro that will allow middleware to only be called if a route is matched, but defined for a list of routes so that it doesn't need to be explicitly done so for each route.

This is my first attempt at writing any Clojure macro so any feedback appreciated! (e.g. I'm not 100% this macro is 'hygienic' enough)

Mike
