### PR TITLE
Update ring to 1.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/core.incubator "0.1.0"]
                  [org.clojure/tools.macro "0.1.0"]
                  [clout "1.1.0"]
-                 [ring/ring-core "1.1.7"]]
+                 [ring/ring-core "1.2.0"]]
   :plugins [[codox "0.6.4"]]
   :codox {:src-dir-uri "http://github.com/weavejester/compojure/blob/1.1.3"
           :src-linenum-anchor-prefix "L"}


### PR DESCRIPTION
I was getting an error that looked like: https://github.com/weavejester/ns-tracker/issues/8

ns-tracker is a dependency of ring, and the fixed version is used by ring 1.2.0, which I am using, but due to a problem similar to: http://stackoverflow.com/questions/17209621/cant-load-hiccup

Compojure, which was using ring 1.1.7 as a dependency, pulled in the broken ns-tracker.

I decided to fork Compojure, update https://github.com/luke0x/compojure/commit/078f98ef7c7b763fad0b6be428af308af96f1669 ring, ran tests, and all looked fine.
