### PR TITLE
URL is decoded twice.

### DIFF
--- a/test/compojure/test/core.clj
+++ b/test/compojure/test/core.clj
@@ -146,3 +146,19 @@
       :post "/foo/10" nil
       :get  "/bar/10" nil
       :get  "/foo"    nil)))
+
+
+(deftest context-url-decoding-test
+  (testing "url encoded percent"
+    (let [handler (GET "/ip/:ip" [ip] ip)
+          context-handler (context "/ip/:ip" [ip]
+                               (GET "/" [] ip))
+          in-context-handler (context "/ip" []
+                            (GET "/:ip" [ip] ip))
+          request (request :get "/ip/0%3A0%3A0%3A0%3A0%3A0%3A0%3A1%250") ]
+      (is (= "0:0:0:0:0:0:0:1%0"
+             (-> request handler :body)))
+      (is (= "0:0:0:0:0:0:0:1%0"
+             (-> request context-handler :body)))
+      (is (= "0:0:0:0:0:0:0:1%0"
+             (-> request in-context-handler :body))))))


### PR DESCRIPTION
Hey,
I have the following problem:

```
(context "/ip" []
    (GET "/:ip" [ip]
       ip))
```

I believe that it should match `http://localhost:3000/ip/0%3A0%3A0%3A0%3A0%3A0%3A0%3A1%250`, which is just url encoded `http://localhost:3000/ip/0:0:0:0:0:0:0:1%0` (IPv6 localhost). The error is `URLDecoder: Incomplete trailing escape (%) pattern` so it just tries to decode %0 again.

It might be related to issue #76.

I created a test that shows the problem. First two tests work, the last one fails (throws exception).
