### PR TITLE
add SUBSCRIBE route macro for use with Rocket

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -151,6 +151,10 @@
   [path args & body]
   (compile-route :patch path args body))
 
+(defmacro SUBSCRIBE "Generate a SUBSCRIBE route."
+  [path args & body]
+  (compile-route :subscribe path args body))
+
 (defmacro ANY "Generate a route that matches any method."
   [path args & body]
   (compile-route nil path args body))


### PR DESCRIPTION
I need to use compojure to create routes for Rocket (http://rocket.github.io), so I added the SUBSCRIBE method macro.
