### PR TITLE
Skip nil handlers while performing routing.

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -113,9 +113,10 @@
       (let-request [~bindings request#] ~@body))))
 
 (defn routing
-  "Apply a list of routes to a Ring request map."
+  "Apply a list of routes to a Ring request map. Skips nil values."
   [request & handlers]
-  (some #(% request) handlers))
+  (->> (remove nil? handlers)
+       (some #(% request))))
 
 (defn routes
   "Create a Ring handler by combining several handlers into one."

--- a/test/compojure/core_test.clj
+++ b/test/compojure/core_test.clj
@@ -109,7 +109,12 @@
 (deftest routing-test
   (routing (mock/request :get "/bar")
     (GET "/foo" [] (is false) nil)
-    (GET "/bar" [] (is true) nil)))
+    (GET "/bar" [] (is true) nil))
+
+  (testing "one route is nil"
+    (routing (mock/request :get "/bar")
+      nil
+      (GET "/bar" [] (is true) nil))))
 
 (deftest routes-test
   ((routes


### PR DESCRIPTION
It would be nice to have ability to have optional routes. Use case: in dev environment you want to have some additional backdoor HTTP-route that should not be present in prod. Something like this:

``` clojure
(defn login-routes [config]
  (routes
    (POST "/login" [] ...)
    (POST "/logout" [] ...)
    (when (= (:env config) :dev)
      (POST "/force-login" [] ...)))
```

Currently it would break if we had some routes defined after "/force-login" route. 

Workaround is not very hard:

``` clojure
(defn login-routes [config]
  (->> [(POST "/login" [] ...)
        (POST "/logout" [] ...)
        (when (= (:env config) :dev)
           (POST "/force-login" [] ...)]
    (remove nil?)
    (apply routes))
```

But it doesn't look as nice and would be handy to have nil-handling in compojure itself.
