### PR TITLE
Add failing test for (route/files "/")

### DIFF
--- a/test/compojure/route_test.clj
+++ b/test/compojure/route_test.clj
@@ -23,12 +23,20 @@
            "text/plain"))))
 
 (deftest files-route
-  (let [route    (route/files "/foo" {:root "test/test_files"})
-        response (route (mock/request :get "/foo/test.txt"))]
-    (is (= (:status response) 200))
-    (is (= (slurp (:body response)) "foobar\n"))
-    (is (= (get-in response [:headers "Content-Type"])
-           "text/plain"))))
+  (testing "text file"
+    (let [route    (route/files "/foo" {:root "test/test_files"})
+          response (route (mock/request :get "/foo/test.txt"))]
+      (is (= (:status response) 200))
+      (is (= (slurp (:body response)) "foobar\n"))
+      (is (= (get-in response [:headers "Content-Type"])
+             "text/plain"))))
+  (testing "root"
+    (let [route    (route/files "/" {:root "test/test_files"})
+          response (route (mock/request :get "/"))]
+      (is (= (:status response) 200))
+      (is (= (slurp (:body response)) "<!doctype html><title></title>\n"))
+      (is (= (get-in response [:headers "Content-Type"])
+             "text/html")))))
 
 (deftest head-method
   (testing "not found"

--- a/test/test_files/index.html
+++ b/test/test_files/index.html
@@ -1,0 +1,1 @@
+<!doctype html><title></title>


### PR DESCRIPTION
Hey,

I've been using `(route/files "/")` as a fallback route for serving static files when doing development without nginx.

Curiously, after upgrading to Compojure 1.2.0 getting the root (i.e. http://localhost:3000)  will serve index.html with the content type application/octet-stream instead of text/html:

```
$ curl -I http://localhost:3000
HTTP/1.1 200 OK
Date: Sun, 19 Oct 2014 18:06:20 GMT
Last-Modified: Sun, 19 Oct 2014 00:17:04 GMT
Content-Length: 1981
Content-Type: application/octet-stream
Server: Jetty(7.6.8.v20121106)
```

Getting the index.html file explicitly will still use the correct content type:

```
$ curl -I http://localhost:3000/index.html
HTTP/1.1 200 OK
Date: Sun, 19 Oct 2014 18:07:54 GMT
Last-Modified: Sun, 19 Oct 2014 00:17:04 GMT
Content-Length: 1981
Content-Type: text/html
Server: Jetty(7.6.8.v20121106)
```

Here is a failing test demonstrating the issue. Downgrading to 1.1.9 makes the issue disappear.
