### PR TITLE
Ensure that vectors are not treated as functions

### DIFF
--- a/src/compojure/response.clj
+++ b/src/compojure/response.clj
@@ -30,7 +30,7 @@
   (render [resp-map _]
     (merge (with-meta (response/response "") (meta resp-map))
            resp-map))
-  clojure.lang.IFn
+  clojure.lang.Fn
   (render [func request] (render (func request) request))
   clojure.lang.IDeref
   (render [ref request] (render (deref ref) request))

--- a/test/compojure/response_test.clj
+++ b/test/compojure/response_test.clj
@@ -58,4 +58,9 @@
   (testing "with map + metadata"
     (let [response (response/render ^{:has-metadata? true} {:body "foo"} {})]
       (is (= (:body response) "foo"))
-      (is (= (meta response) {:has-metadata? true})))))
+      (is (= (meta response) {:has-metadata? true}))))
+
+  (testing "with vector"
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"No implementation of method: :render of protocol: #'compojure.response/Renderable"
+                          (response/render [] {})))))


### PR DESCRIPTION
As discussed in #127, this improves error message when returning vector from route.
