### PR TITLE
Fix context use with list and regex.

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -195,7 +195,7 @@
        `(clout/route-compile ~(str route ":__path-info") ~re-context)
       (vector? route)
        `(clout/route-compile
-         ~(str (first route) ":__path-info")
+         (str ~(first route) ":__path-info")
          ~(merge (apply hash-map (rest route)) re-context))
       :else
        `(clout/route-compile (str ~route ":__path-info") ~re-context))))

--- a/test/compojure/core_test.clj
+++ b/test/compojure/core_test.clj
@@ -139,6 +139,12 @@
       (is (map? (handler (mock/request :get "/foo/10"))))
       (is (nil? (handler (mock/request :get "/bar/10"))))))
 
+  (testing "list with regex matching"
+    (let [handler (context [(str "/foo" "/:id") :id #"\d+"] [id] identity)]
+      (is (map? (handler (mock/request :get "/foo/10"))))
+      (is (nil? (handler (mock/request :get "/foo/ab"))))
+      (is (nil? (handler (mock/request :get "/bar/10"))))))
+
   (testing "context key"
     (let [handler (context "/foo/:id" [id] :context)]
       (are [url ctx] (= (handler (mock/request :get url)) ctx)


### PR DESCRIPTION
Usage of the context macro with a list as path and a regexp for validation now matches correctly.
