### PR TITLE
(FOR REVIEW/WIP): add route metadata

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject compojure "1.3.1"
+(defproject compojure "1.3.2-SNAPSHOT"
   :description "A concise routing library for Ring"
   :url "https://github.com/weavejester/compojure"
   :license {:name "Eclipse Public License"

--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -97,11 +97,14 @@
   "Returns a function that will only call the handler if the method and path
   match the request."
   [method path handler]
-  (if-method method
-    (if-route path
-      (wrap-route-middleware
-        (fn [request]
-          (response/render (handler request) request))))))
+  (with-meta
+    (if-method method
+      (if-route path
+        (wrap-route-middleware
+          (fn [request]
+            (response/render (handler request) request)))))
+    {:method method
+     :path path}))
 
 (defn compile-route
   "Compile a route in the form (method path bindings & body) into a function.
@@ -120,7 +123,9 @@
 (defn routes
   "Create a Ring handler by combining several handlers into one."
   [& handlers]
-  #(apply routing % handlers))
+  (with-meta
+    #(apply routing % handlers)
+    {:routes (mapv meta handlers)}))
 
 (defmacro defroutes
   "Define a Ring handler function from a sequence of routes. The name may

--- a/test/compojure/core_test.clj
+++ b/test/compojure/core_test.clj
@@ -249,3 +249,20 @@
       (dotimes [_ 10]
         (handler (mock/request :get "/foo")))
       (is (= @counter 1)))))
+
+(deftest route-metadata-test
+  (testing "routes provide metadata"
+    (let [handler (routes
+                    (GET "/foo" [] nil)
+                    (DELETE "/foobar" [] nil)
+                    (ANY "/bar/:baz/:bam" [baz bam] nil))
+          metadata (meta handler)]
+      (is (map? metadata))
+      (is (contains? metadata :routes))
+      (is (= 3 (count (:routes metadata))))
+      (let [[foo foobar bar] (:routes metadata)]
+        (is (= :get (:method foo)))
+        (is (= "/foo" (-> foo :path :source)))
+        (is (= :delete (:method foobar)))
+        (is (nil? (:method bar)))
+        (is (= [:baz :bam] (-> bar :path :keys)))))))


### PR DESCRIPTION
I have some use cases where it would be really valuable to be able to introspect the result of a call to `routes` or `context` and gather some metadata about the routes that had been defined.  I started playing around with the code to see what it might look like, and it turned out to be really easy for `routes` (sample code below)... but once I started trying to do it for `context` as well, it got a lot more complicated.  I was trying to add a test that looked something like this:

```clj
(testing "nested routes provide metadata"
   (let [handler (context "/foo/:id" [id]
                           (GET "/" [] "root")
                           (GET "/id" [] id)
                           (GET "/x/:x" [x] x))
          metadata (meta handler)]
      (println "META:" metadata))) 
```

But it was really hard to see a way to modify `context` to support this, because the routes get compiled inside of the `let-request` block and I didn't see an easy way to collect their metadata from inside there and bubble it back up to the `if-context` part of the macro.

So... thought I'd just throw this up for review.  Two questions:

1. Would you be amenable to a patch like this that provides metadata about the routes / contexts?
2. If so, any ideas/preferences on how to proceed on getting it to work for `context`?

Thanks!