### PR TITLE
Make matched route info available to middleware

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -117,17 +117,20 @@
       ((mw handler) request)
       (handler request))))
 
+(defn- wrap-route-info [handler route-info]
+  (fn [request]
+    (handler (assoc request :compojure/route route-info))))
+
 (defn make-route
   "Returns a function that will only call the handler if the method and path
   match the request."
   [method path handler]
-   (let [route-info [(or method :any) (str path)]]
-     (if-method method
-       (if-route path
-         (wrap-route-middleware
-           (fn [request]
-             (let [request (assoc request :compojure/route route-info)]
-               (response/render (handler request) request))))))))
+  (let [route-info [(or method :any) (str path)]]
+    (if-method method
+      (if-route path
+        (-> (fn [request] (response/render (handler request) request))
+            (wrap-route-middleware)
+            (wrap-route-info route-info))))))
 
 (defn compile-route
   "Compile a route in the form (method path bindings & body) into a function.

--- a/test/compojure/core_test.clj
+++ b/test/compojure/core_test.clj
@@ -265,7 +265,15 @@
           handler    (wrap-routes route middleware)]
       (dotimes [_ 10]
         (handler (mock/request :get "/foo")))
-      (is (= @counter 1)))))
+      (is (= @counter 1))))
+
+  (testing "matched route available in request"
+    (let [route      (GET "/foo" [] "foo")
+          matched    (atom nil)
+          middleware (fn [h] (fn [r] (reset! matched (:compojure/route r)) (h r)))
+          handler    (wrap-routes route middleware)
+          response   (handler (mock/request :get "/foo"))]
+      (is (= @matched [:get "/foo"])))))
 
 (deftest route-information-test
   (let [route (GET "/foo/:id" req req)


### PR DESCRIPTION
The utility of the `:compojure/route` key recently introduced into the request map was limited by the fact that it was unavailable to middleware functions due that functionality being nested inside the wrap-route-middleware handler. This adds an additional wrapper to assoc the matched route into the request before the route middleware is invoked. This makes it possible to implement generic route-based logging centrally in middleware, for example.