### PR TITLE
Add support for multimethods as render functions

### DIFF
--- a/src/compojure/response.clj
+++ b/src/compojure/response.clj
@@ -31,6 +31,8 @@
            resp-map))
   clojure.lang.Fn
   (render [func request] (render (func request) request))
+  clojure.lang.MultiFn
+  (render [func request] (render (func request) request))
   clojure.lang.IDeref
   (render [ref request] (render (deref ref) request))
   java.io.File

--- a/test/compojure/response_test.clj
+++ b/test/compojure/response_test.clj
@@ -8,6 +8,12 @@
    :headers {"Content-Type" "text/html; charset=utf-8"}
    :body    "<h1>Foo</h1>"})
 
+
+(defmulti handler-multi :body)
+
+(defmethod handler-multi :default [request]
+  expected-response)
+
 (deftest response-test
   (testing "with nil"
     (is (nil? (response/render nil {}))))
@@ -24,6 +30,10 @@
 
   (testing "with handler function"
     (is (= (response/render (constantly expected-response) {})
+           expected-response)))
+
+  (testing "with handler multimethod"
+    (is (= (response/render handler-multi {})
            expected-response)))
 
   (testing "with deref-able"


### PR DESCRIPTION
Currently it's not possible to use multimethods as render fns because `clojure.lang.MultiFn` doesn't implement `clojure.lang.Fn`:

```
java.lang.IllegalArgumentException: No implementation of method: :render of protocol: 
#'compojure.response/Renderable found for class: clojure.lang.MultiFn
```