### PR TITLE
Allow dotfiles to be ignored in file serving functions

### DIFF
--- a/test/compojure/route_test.clj
+++ b/test/compojure/route_test.clj
@@ -3,6 +3,9 @@
             [ring.mock.request :as mock]
             [compojure.route :as route]))
 
+(defn- map-subset? [m1 m2]
+  (clojure.set/subset? (set m1) (set m2)))
+
 (deftest not-found-route
   (testing "string body"
     (let [response ((route/not-found "foo") (mock/request :get "/"))]
@@ -23,12 +26,37 @@
       (is (= (:body @response) "baz")))))
 
 (deftest resources-route
-  (let [route    (route/resources "/foo" {:root "test_files"})
-        response (route (mock/request :get "/foo/test.txt"))]
-    (is (= (:status response) 200))
-    (is (= (slurp (:body response)) "foobar\n"))
-    (is (= (get-in response [:headers "Content-Type"])
-           "text/plain"))))
+  (testing "text file"
+    (let [route    (route/resources "/foo" {:root "test_files"})
+          response (route (mock/request :get "/foo/test.txt"))]
+      (is (= (:status response) 200))
+      (is (= (slurp (:body response)) "foobar\n"))
+      (is (= (get-in response [:headers "Content-Type"])
+            "text/plain"))))
+  (testing "dotfile, implicitly allowed"
+    (let [route    (route/resources "/foo" {:root "test_files"})
+          response (route (mock/request :get "/foo/.dotfile"))]
+      (is (= (:status response) 200))
+      (is (= (slurp (:body response)) "bingbong\n"))))
+  (testing "dotfile, explicitly allowed"
+    (let [route    (route/resources "/foo" {:root "test_files"
+                                            :dotfiles? (constantly true)})
+          response (route (mock/request :get "/foo/.dotfile"))]
+      (is (= (:status response) 200))
+      (is (= (slurp (:body response)) "bingbong\n"))))
+  (testing "dotfile, ignored"
+    (let [route    (route/resources "/foo" {:root "test_files"
+                                            :dotfiles? (constantly false)})
+          response (route (mock/request :get "/foo/.dotfile"))]
+      (is (nil? response))))
+  (testing "dotfiles? function is called with the request"
+    (let [actual-request (atom nil)
+          mock-request   (mock/request :get "/foo/.dotfile")
+          dotfiles?      (partial reset! actual-request)
+          route          (route/resources "/foo" {:root "test_files"
+                                                  :dotfiles? dotfiles?})]
+      (route mock-request)
+      (is (map-subset? (set mock-request) (set @actual-request))))))
 
 (deftest files-route
   (testing "text file"
@@ -38,6 +66,30 @@
       (is (= (slurp (:body response)) "foobar\n"))
       (is (= (get-in response [:headers "Content-Type"])
              "text/plain"))))
+  (testing "dotfile, implicitly allowed"
+    (let [route    (route/files "/foo" {:root "test/test_files"})
+          response (route (mock/request :get "/foo/.dotfile"))]
+      (is (= (:status response) 200))
+      (is (= (slurp (:body response)) "bingbong\n"))))
+  (testing "dotfile, explicitly allowed"
+    (let [route    (route/files "/foo" {:root "test/test_files"
+                                        :dotfiles? (constantly true)})
+          response (route (mock/request :get "/foo/.dotfile"))]
+      (is (= (:status response) 200))
+      (is (= (slurp (:body response)) "bingbong\n"))))
+  (testing "dotfile, ignored"
+    (let [route    (route/files "/foo" {:root "test/test_files"
+                                        :dotfiles? (constantly false)})
+          response (route (mock/request :get "/foo/.dotfile"))]
+      (is (nil? response))))
+  (testing "dotfiles? function is called with the request"
+    (let [actual-request (atom nil)
+          mock-request   (mock/request :get "/foo/.dotfile")
+          dotfiles?      (partial reset! actual-request)
+          route          (route/files "/foo" {:root "test_files"
+                                              :dotfiles? dotfiles?})]
+      (route mock-request)
+      (is (map-subset? (set mock-request) (set @actual-request)))))
   (testing "root"
     (let [route    (route/files "/" {:root "test/test_files"})
           response (route (mock/request :get "/"))]

--- a/test/test_files/.dotfile
+++ b/test/test_files/.dotfile
@@ -1,0 +1,1 @@
+bingbong


### PR DESCRIPTION
This PR adds a `:dotfiles?` option which allows files that begin with `.` to be ignored by `routes/files` and `routes/resources`.

This is inspired by an option from [Express.js's static file middleware](https://expressjs.com/en/4x/api.html#express.static).