### PR TITLE
Update Ring to 1.6.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/tools.macro "0.1.5"]
                  [clout "2.1.2"]
                  [medley "1.0.0"]
-                 [ring/ring-core "1.6.0"]
+                 [ring/ring-core "1.6.3"]
                  [ring/ring-codec "1.0.1"]]
   :plugins [[lein-codox "0.10.3"]]
   :codox


### PR DESCRIPTION
commons-fileupload 1.3.3, which is part of Ring 1.6.3, resolves http://www.cvedetails.com/cve/CVE-2016-1000031/