### PR TITLE
Add the route context to the request map

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -255,13 +255,14 @@
   (if-let [params (clout/route-matches route request)]
     (let [uri     (:uri request)
           path    (:path-info request uri)
-          context (or (:context request) "")
           subpath (:__path-info params)
-          params  (dissoc params :__path-info)]
+          params  (dissoc params :__path-info)
+          context (remove-suffix (str route) ":__path-info")]
       (-> request
           (assoc-route-params (decode-route-params params))
           (assoc :path-info (if (= subpath "") "/" subpath)
-                 :context   (remove-suffix uri subpath))))))
+                 :context   (remove-suffix uri subpath))
+          (update :compojure/context str context)))))
 
 (defn- context-route [route]
   (let [re-context {:__path-info #"|/.*"}]


### PR DESCRIPTION
This provides access to the route prefix as a companion to the existing `:compojure/route` data allowing the full route to be reconstructed. Since the `context` macro only accepts a path the new `:compojure/context` value simply contains the route path instead of the `[method route]` pair present in `:compojure/route`.

This data was introduced as a new field in the request path, rather than updating `:compojure/route` to include the context for the sake of backwards compatibility.