### PR TITLE
Update Medley to 1.4.0 to fix Clojure 1.11 warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.macro "0.1.5"]
                  [clout "2.2.1"]
-                 [medley "1.3.0"]
+                 [medley "1.4.0"]
                  [ring/ring-core "1.8.1"]
                  [ring/ring-codec "1.1.2"]]
   :plugins [[lein-codox "0.10.7"]]


### PR DESCRIPTION
Fixes #205

* Commit message 50 chars or less, follows seven rules
* Follows Clojure Style Guide
* **All tests pass**
   ```sh
   $ lein test
   # <snip>
   Ran 21 tests containing 191 assertions.
   0 failures, 0 errors.
   ```

We are also going to need a new release after this is merged. I'll open a new issue for that if needed. Many thanks for your time and effort on these updates!