### PR TITLE
Add a full-route key to the request map

### DIFF
--- a/src/compojure/core.clj
+++ b/src/compojure/core.clj
@@ -134,9 +134,11 @@
 (defn- wrap-route-info [handler route-info]
   (fn
     ([request]
-     (handler (assoc request :compojure/route route-info)))
+     (handler (assoc request :compojure/route route-info
+                     :compojure/full-route (str (:compojure/context request) (second route-info)))))
     ([request respond raise]
-     (handler (assoc request :compojure/route route-info) respond raise))))
+     (handler (assoc request :compojure/route route-info
+                     :compojure/full-route (str (:compojure/context request) (second route-info)) respond raise)))))
 
 (defn- wrap-route-matches [handler method path]
   (fn
@@ -257,27 +259,37 @@
           path    (:path-info request uri)
           context (or (:context request) "")
           subpath (:__path-info params)
-          params  (dissoc params :__path-info)]
+          params  (dissoc params :__path-info)
+          context-route (:context-route (meta route))]
       (-> request
           (assoc-route-params (decode-route-params params))
           (assoc :path-info (if (= subpath "") "/" subpath)
-                 :context   (remove-suffix uri subpath))))))
+                 :context   (remove-suffix uri subpath)
+                 :compojure/context (str (:compojure/context request) context-route))))))
 
 (defn- context-route [route]
   (let [re-context {:__path-info #"|/.*"}]
-    (cond
-      (string? route)
-        (clout/route-compile (str route ":__path-info") re-context)
-      (and (vector? route) (literal? route))
-        (clout/route-compile
-         (str (first route) ":__path-info")
-         (merge (apply hash-map (rest route)) re-context))
-      (vector? route)
-       `(clout/route-compile
-         (str ~(first route) ":__path-info")
-         ~(merge (apply hash-map (rest route)) re-context))
-      :else
-       `(clout/route-compile (str ~route ":__path-info") ~re-context))))
+        (cond
+          (string? route)
+          (with-meta (clout/route-compile (str route ":__path-info") re-context) {:context-route route})
+          (and (vector? route) (literal? route))
+          (with-meta (clout/route-compile
+                      (str (first route) ":__path-info")
+                      (merge (apply hash-map (rest route)) re-context)) {:context-route (first route)})
+          (vector? route)
+          `(let [uncompiled-route# ~(first route)]
+             (with-meta
+               (clout/route-compile
+                (str uncompiled-route# ":__path-info")
+                ~(merge (apply hash-map (rest route)) re-context))
+               {:context-route uncompiled-route#}))
+          :else
+          `(let [path# ~route]
+             (with-meta
+                (clout/route-compile (str path# ":__path-info") ~re-context)
+               (if (string? path#)
+                 {:context-route path#}
+                 {}))))))
 
 (defn ^:no-doc make-context [route make-handler]
   (letfn [(handler

--- a/test/compojure/core_test.clj
+++ b/test/compojure/core_test.clj
@@ -212,7 +212,7 @@
     (let [handler        (GET "/ip/:ip" [ip] ip)
           cxt-handler    (context "/ip/:ip" [ip] (GET "/" [] ip))
           in-cxt-handler (context "/ip" [] (GET "/:ip" [ip] ip))
-          request        (mock/request :get "/ip/0%3A0%3A0%3A0%3A0%3A0%3A0%3A1%250") ]
+          request        (mock/request :get "/ip/0%3A0%3A0%3A0%3A0%3A0%3A0%3A1%250")]
       (is (= (-> request handler :body)        "0:0:0:0:0:0:0:1%0"))
       (is (= (-> request cxt-handler :body)    "0:0:0:0:0:0:0:1%0"))
       (is (= (-> request in-cxt-handler :body) "0:0:0:0:0:0:0:1%0"))))
@@ -221,7 +221,7 @@
     (let [handler        (GET "/emote/:emote" [emote] emote)
           cxt-handler    (context "/emote/:emote" [emote] (GET "/" [] emote))
           in-cxt-handler (context "/emote" [] (GET "/:emote" [emote] emote))
-          request        (mock/request :get "/emote/%5C%3F%2F") ]
+          request        (mock/request :get "/emote/%5C%3F%2F")]
       (is (= (-> request handler :body)        "\\?/"))
       (is (= (-> request cxt-handler :body)    "\\?/"))
       (is (= (-> request in-cxt-handler :body) "\\?/"))))
@@ -323,7 +323,21 @@
         request (route (mock/request :post "/foo/1" {}))]
     (testing "ANY request has matched route information"
       (is (= (request :compojure/route)
-             [:any "/foo/:id"])))))
+             [:any "/foo/:id"]))))
+
+  (let [route (context "/foo/:foo-id" [_] (GET "/bar/:bar-id" req req))
+        request (route (mock/request :get "/foo/1/bar/2"))]
+    (testing "request has matched route information with path prefix"
+      (is (= (request :compojure/full-route)
+             "/foo/:foo-id/bar/:bar-id"))))
+
+  (let [route (context "/foo/:foo-id" [_]
+                (context "/bar/:bar-id" [_]
+                  (GET "/baz/:baz-id" req req)))
+        request (route (mock/request :get "/foo/1/bar/2/baz/3"))]
+    (testing "request has matched route information with multiple path prefix"
+      (is (= (request :compojure/full-route)
+             "/foo/:foo-id/bar/:bar-id/baz/:baz-id")))))
 
 (deftest route-async-test
   (testing "single route"


### PR DESCRIPTION
This provides access to the full route that contains the common prefix.
The full-route info is added to the `:compojure/full-route` key in the request map.