### PR TITLE
Use full request to check for canonical URI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/weavejester/compojure"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.macro "0.1.5"]
                  [clout "2.2.1"]
                  [medley "1.4.0"]

--- a/src/compojure/middleware.clj
+++ b/src/compojure/middleware.clj
@@ -1,41 +1,36 @@
 (ns compojure.middleware
   "Optional middleware to enhance routing in Compojure."
   (:require [compojure.core :refer [wrap-routes]]
-            [ring.util.response :as resp]))
+            [ring.util.request :as req]
+            [ring.util.response :as resp]
+
+            [clojure.string :as str]))
 
 (defn remove-trailing-slash
-  "Remove the trailing '/' from a URI string, if it exists."
-  [^String uri]
-  (if (.endsWith uri "/")
-    (.substring uri 0 (dec (.length uri)))
-    uri))
+  "Remove the trailing '/' from the path of a request, if it exists."
+  [request]
+  (update request :uri #(if (str/ends-with? % "/")
+                          (subs % 0 (dec (count %)))
+                          %)))
 
 (defn- redirect-to-canonical
   ([request]
-   (resp/redirect (:compojure/path request) 301))
+   (resp/redirect (req/request-url request) 301))
   ([request respond raise]
    (respond (redirect-to-canonical request))))
 
-(defn- assoc-path [request path]
-  (assoc request :compojure/path path))
-
 (defn wrap-canonical-redirect
   "Middleware that permanently redirects any non-canonical route to its
-  canonical equivalent, based on a make-canonical function that changes a URI
-  string into its canonical form. If not supplied, the make-canonical function
+  canonical equivalent, based on a make-canonical function that changes the URI
+  in a request into its canonical form. If not supplied, the make-canonical function
   will default to [[remove-trailing-slash]]."
   ([handler]
    (wrap-canonical-redirect handler remove-trailing-slash))
   ([handler make-canonical]
    (let [redirect-handler (wrap-routes handler (constantly redirect-to-canonical))]
      (fn
-       ([{uri :uri :as request}]
-        (let [canonical-uri (make-canonical uri)]
-          (if (= uri canonical-uri)
-            (handler request)
-            (redirect-handler (assoc-path request canonical-uri)))))
-       ([{uri :uri :as request} respond raise]
-        (let [canonical-uri (make-canonical uri)]
-          (if (= uri canonical-uri)
-            (handler request respond raise)
-            (redirect-handler (assoc-path request canonical-uri) respond raise))))))))
+       ([request & args]
+        (let [canonical-request (make-canonical request)]
+          (if (= request canonical-request)
+            (apply handler request args)
+            (apply redirect-handler canonical-request args))))))))

--- a/test/compojure/middleware_test.clj
+++ b/test/compojure/middleware_test.clj
@@ -18,11 +18,15 @@
             :body "foo"}))
     (is (= (handler (mock/request :get "/foo/"))
            {:status 301
-            :headers {"Location" "/foo"}
+            :headers {"Location" "http://localhost/foo"}
             :body ""}))
     (is (= (handler (mock/request :get "/bar/"))
            {:status 301
-            :headers {"Location" "/bar"}
+            :headers {"Location" "http://localhost/bar"}
+            :body ""}))
+    (is (= (handler (mock/request :get "/foo/?bar=baz"))
+           {:status 301
+            :headers {"Location" "http://localhost/foo?bar=baz"}
             :body ""}))
     (is (= (handler (mock/request :get "/baz/"))
            {:status 404
@@ -48,5 +52,5 @@
         (is (not (realized? exception)))
         (is (= @response
                {:status 301
-                :headers {"Location" "/foo"}
+                :headers {"Location" "http://localhost/foo"}
                 :body ""}))))))


### PR DESCRIPTION
I needed this to keep the query string when redirecting to the canonical URI.
Furthermore, I think it allows you to make more changes to the canonical URI, such as changing the host...