### PR TITLE
Update Ring to 1.10.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/tools.macro "0.1.5"]
                  [clout "2.2.1"]
                  [medley "1.4.0"]
-                 [ring/ring-core "1.9.5"]
+                 [ring/ring-core "1.10.0"]
                  [ring/ring-codec "1.2.0"]]
   :plugins [[lein-codox "0.10.7"]]
   :codox


### PR DESCRIPTION
Update to latest Ring that has fix for Apache Commons File upload vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2023-24998

Related https://github.com/ring-clojure/ring/issues/476