### PR TITLE
Upgrade medley

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.macro "0.1.5"]
                  [clout "2.2.1"]
-                 [medley "1.4.0"]
+                 [dev.weavejester/medley "1.9.0"]
                  [ring/ring-core "1.11.0"]
                  [ring/ring-codec "1.2.0"]]
   :plugins [[lein-codox "0.10.7"]]


### PR DESCRIPTION
We're using the latest medley in our project, which changed organization name. This means that we end up with two versions of medley on our classpath - medley 1.4.0 and dev.weavejester/medley 1.9.0. This caused us some grief with clj-kondo.

This commit upgrades medley to the latest released version to fix this problem.